### PR TITLE
Add sql.Scanner implementations for several types

### DIFF
--- a/xdr/db.go
+++ b/xdr/db.go
@@ -1,0 +1,53 @@
+package xdr
+
+import (
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+// This file contains implementations of the sql.Scanner interface for stellar xdr types
+
+func (this *AccountFlags) Scan(src interface{}) error {
+	val, ok := src.(int32)
+	if !ok {
+		return errors.New("Invalid value for xdr.AssetType")
+	}
+
+	*this = AccountFlags(val)
+	return nil
+}
+
+func (this *AssetType) Scan(src interface{}) error {
+	val, ok := src.(int32)
+	if !ok {
+		return errors.New("Invalid value for xdr.AssetType")
+	}
+
+	*this = AssetType(val)
+	return nil
+}
+
+func (this *Int64) Scan(src interface{}) error {
+	val, ok := src.(int64)
+	if !ok {
+		return errors.New("Invalid value for xdr.Int64")
+	}
+
+	*this = Int64(val)
+	return nil
+}
+
+func (this *Thresholds) Scan(src interface{}) error {
+	val, ok := src.(string)
+	if !ok {
+		return errors.New("Invalid value for xdr.Int64")
+	}
+
+	reader := strings.NewReader(val)
+	b64r := base64.NewDecoder(base64.StdEncoding, reader)
+
+	_, err := Unmarshal(b64r, this)
+	return err
+
+}

--- a/xdr/db.go
+++ b/xdr/db.go
@@ -11,7 +11,7 @@ import (
 func (this *AccountFlags) Scan(src interface{}) error {
 	val, ok := src.(int32)
 	if !ok {
-		return errors.New("Invalid value for xdr.AssetType")
+		return errors.New("Invalid value for xdr.AccountFlags")
 	}
 
 	*this = AccountFlags(val)
@@ -41,7 +41,7 @@ func (this *Int64) Scan(src interface{}) error {
 func (this *Thresholds) Scan(src interface{}) error {
 	val, ok := src.(string)
 	if !ok {
-		return errors.New("Invalid value for xdr.Int64")
+		return errors.New("Invalid value for xdr.Thresholds")
 	}
 
 	reader := strings.NewReader(val)

--- a/xdr/db_test.go
+++ b/xdr/db_test.go
@@ -1,0 +1,88 @@
+package xdr_test
+
+import (
+	. "github.com/stellar/go-stellar-base/xdr"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sql.Scanner implementations", func() {
+
+	DescribeTable("AccountFlags",
+		func(in interface{}, val AccountFlags, shouldSucceed bool) {
+			var scanned AccountFlags
+			err := scanned.Scan(in)
+
+			if shouldSucceed {
+				Expect(err).To(BeNil())
+			} else {
+				Expect(err).ToNot(BeNil())
+			}
+
+			Expect(scanned).To(Equal(val))
+		},
+		Entry("zero", int32(0), AccountFlags(0), true),
+		Entry("required", int32(1), AccountFlags(1), true),
+		Entry("revokable", int32(2), AccountFlags(2), true),
+		Entry("immutable", int32(4), AccountFlags(4), true),
+		Entry("string", "0", AccountFlags(0), false),
+	)
+
+	DescribeTable("AssetType",
+		func(in interface{}, val AssetType, shouldSucceed bool) {
+			var scanned AssetType
+			err := scanned.Scan(in)
+
+			if shouldSucceed {
+				Expect(err).To(BeNil())
+			} else {
+				Expect(err).ToNot(BeNil())
+			}
+
+			Expect(scanned).To(Equal(val))
+		},
+		Entry("native", int32(0), AssetTypeAssetTypeNative, true),
+		Entry("credit alphanum4", int32(1), AssetTypeAssetTypeCreditAlphanum4, true),
+		Entry("credit alphanum12", int32(2), AssetTypeAssetTypeCreditAlphanum12, true),
+		Entry("string", "native", AssetTypeAssetTypeNative, false),
+	)
+
+	DescribeTable("Int64",
+		func(in interface{}, val Int64, shouldSucceed bool) {
+			var scanned Int64
+			err := scanned.Scan(in)
+
+			if shouldSucceed {
+				Expect(err).To(BeNil())
+			} else {
+				Expect(err).ToNot(BeNil())
+			}
+
+			Expect(scanned).To(Equal(val))
+		},
+		Entry("pos", int64(1), Int64(1), true),
+		Entry("neg", int64(-1), Int64(-1), true),
+		Entry("zero", int64(0), Int64(0), true),
+		Entry("string", "0", Int64(0), false),
+	)
+
+	DescribeTable("Thresholds",
+		func(in interface{}, val Thresholds, shouldSucceed bool) {
+			var scanned Thresholds
+			err := scanned.Scan(in)
+
+			if shouldSucceed {
+				Expect(err).To(BeNil())
+			} else {
+				Expect(err).ToNot(BeNil())
+			}
+
+			Expect(scanned).To(Equal(val))
+		},
+		Entry("default", "AQAAAA==", Thresholds{0x01, 0x00, 0x00, 0x00}, true),
+		Entry("non-default", "AgACAg==", Thresholds{0x02, 0x00, 0x02, 0x02}, true),
+		Entry("number", 0, Thresholds{}, false),
+	)
+})


### PR DESCRIPTION
This PR enables the direct `Scan()`ing of data from a database row into some of our xdr types:

- xdr.Int64
- xdr.AssetType
- xdr.AccountFlags
- xdr.Thresholds