### PR TITLE
Allow trust builder

### DIFF
--- a/build/allow_trust.go
+++ b/build/allow_trust.go
@@ -1,0 +1,78 @@
+package build
+
+import (
+	"errors"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// AllowTrust groups the creation of a new AllowTrustBuilder with a call to Mutate.
+func AllowTrust(muts ...interface{}) (result AllowTrustBuilder) {
+	result.Mutate(muts...)
+	return
+}
+
+// AllowTrustMutator is a interface that wraps the
+// MutatePayment operation.  types may implement this interface to
+// specify how they modify an xdr.AllowTrustOp object
+type AllowTrustMutator interface {
+	MutateAllowTrust(*xdr.AllowTrustOp) error
+}
+
+// AllowTrustBuilder represents a transaction that is being built.
+type AllowTrustBuilder struct {
+	O   xdr.Operation
+	AT  xdr.AllowTrustOp
+	Err error
+}
+
+// Mutate applies the provided mutators to this builder's payment or operation.
+func (b *AllowTrustBuilder) Mutate(muts ...interface{}) {
+	for _, m := range muts {
+		var err error
+		switch mut := m.(type) {
+		case AllowTrustMutator:
+			err = mut.MutateAllowTrust(&b.AT)
+		case OperationMutator:
+			err = mut.MutateOperation(&b.O)
+		}
+
+		if err != nil {
+			b.Err = err
+			return
+		}
+	}
+}
+
+// MutateAllowTrust for Authorize sets the AllowTrustOp's Authorize field
+func (m Authorize) MutateAllowTrust(o *xdr.AllowTrustOp) {
+	o.Authorize = m.Value
+}
+
+// MutateAllowTrust for Asset sets the AllowTrustOp's Asset field
+func (m AllowTrustAsset) MutateAllowTrust(o *xdr.AllowTrustOp) (err error) {
+	var assetType xdr.AssetType
+	var code []byte
+	length := len(m.Code)
+
+	switch {
+	case length >= 1 && length <= 4:
+		assetType = xdr.AssetTypeAssetTypeCreditAlphanum4
+		code = make([]byte, 4)
+	case length >= 5 && length <= 12:
+		assetType = xdr.AssetTypeAssetTypeCreditAlphanum12
+		code = make([]byte, 12)
+	default:
+		return errors.New("Asset code length is invalid")
+	}
+
+	byteArray := []byte(m.Code)
+	copy(code, byteArray[:length])
+
+	o.Asset, err = xdr.NewAllowTrustOpAsset(assetType, code)
+	return
+}
+
+// MutateAllowTrust for Trustor sets the AllowTrustOp's Trustor field
+func (m Trustor) MutateAllowTrust(o *xdr.AllowTrustOp) error {
+	return setAccountId(m.Address, &o.Trustor)
+}

--- a/build/allow_trust_test.go
+++ b/build/allow_trust_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stellar/go-stellar-base/xdr"
 )
 
-var _ = Describe("Payment Mutators", func() {
+var _ = Describe("AllowTrustBuilder Mutators", func() {
 
 	var (
 		subject AllowTrustBuilder
@@ -86,6 +86,28 @@ var _ = Describe("Payment Mutators", func() {
 				Expect(*subject.AT.Asset.AssetCode12).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
 			})
 		})
+
+		Context("asset code length invalid", func() {
+			Context("empty", func() {
+				BeforeEach(func() {
+					mut = AllowTrustAsset{""}
+				})
+
+				It("failed", func() {
+					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+				})
+			});
+
+			Context("too long", func() {
+				BeforeEach(func() {
+					mut = AllowTrustAsset{"1234567890123"}
+				})
+
+				It("failed", func() {
+					Expect(subject.Err).To(MatchError("Asset code length is invalid"))
+				})
+			});
+		})
 	})
 
 	Describe("Authorize", func() {
@@ -101,6 +123,7 @@ var _ = Describe("Payment Mutators", func() {
 
 		Context("when equal false", func() {
 			BeforeEach(func() {
+				subject.AT.Authorize = true
 				mut = Authorize{false}
 			})
 

--- a/build/allow_trust_test.go
+++ b/build/allow_trust_test.go
@@ -1,0 +1,114 @@
+package build
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/stellar/go-stellar-base"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+var _ = Describe("Payment Mutators", func() {
+
+	var (
+		subject AllowTrustBuilder
+		mut     interface{}
+
+		address = "GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ"
+		bad     = "foo"
+	)
+
+	JustBeforeEach(func() {
+		subject = AllowTrustBuilder{}
+		subject.Mutate(mut)
+	})
+
+	Describe("Trustor", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = Trustor{address} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.AT.Trustor.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = Trustor{bad} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("SourceAccount", func() {
+		Context("using a valid stellar address", func() {
+			BeforeEach(func() { mut = SourceAccount{address} })
+
+			It("succeeds", func() {
+				Expect(subject.Err).NotTo(HaveOccurred())
+			})
+
+			It("sets the destination to the correct xdr.AccountId", func() {
+				aid, _ := stellarbase.AddressToAccountId(address)
+				Expect(subject.O.SourceAccount.MustEd25519()).To(Equal(aid.MustEd25519()))
+			})
+		})
+
+		Context("using an invalid value", func() {
+			BeforeEach(func() { mut = SourceAccount{bad} })
+			It("failed", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+	})
+
+	Describe("AllowTrustAsset", func() {
+		Context("AssetTypeCreditAlphanum4", func() {
+			BeforeEach(func() {
+				mut = AllowTrustAsset{"USD"}
+			})
+
+			It("sets Asset properly", func() {
+				Expect(subject.AT.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
+				Expect(subject.AT.Asset.AssetCode4).To(Equal([4]byte{'U', 'S', 'D', 0}))
+				Expect(subject.AT.Asset.AssetCode12).To(BeNil())
+			})
+		})
+
+		Context("AssetTypeCreditAlphanum12", func() {
+			BeforeEach(func() {
+				mut = AllowTrustAsset{"ABCDEF"}
+			})
+
+			It("sets Asset properly", func() {
+				Expect(subject.AT.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum12))
+				Expect(subject.AT.Asset.AssetCode4).To(BeNil())
+				Expect(subject.AT.Asset.AssetCode12).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
+			})
+		})
+	})
+
+	Describe("Authorize", func() {
+		Context("when equal true", func() {
+			BeforeEach(func() {
+				mut = Authorize{true}
+			})
+
+			It("sets authorize flag properly", func() {
+				fmt.Println(subject.AT.Authorize)
+				Expect(subject.AT.Authorize).To(Equal(true))
+			})
+		})
+
+		Context("when equal false", func() {
+			BeforeEach(func() {
+				mut = Authorize{false}
+			})
+
+			It("sets authorize flag properly", func() {
+				Expect(subject.AT.Authorize).To(Equal(false))
+			})
+		})
+	})
+})

--- a/build/allow_trust_test.go
+++ b/build/allow_trust_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stellar/go-stellar-base"
@@ -71,7 +70,7 @@ var _ = Describe("Payment Mutators", func() {
 
 			It("sets Asset properly", func() {
 				Expect(subject.AT.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum4))
-				Expect(subject.AT.Asset.AssetCode4).To(Equal([4]byte{'U', 'S', 'D', 0}))
+				Expect(*subject.AT.Asset.AssetCode4).To(Equal([4]byte{'U', 'S', 'D', 0}))
 				Expect(subject.AT.Asset.AssetCode12).To(BeNil())
 			})
 		})
@@ -84,7 +83,7 @@ var _ = Describe("Payment Mutators", func() {
 			It("sets Asset properly", func() {
 				Expect(subject.AT.Asset.Type).To(Equal(xdr.AssetTypeAssetTypeCreditAlphanum12))
 				Expect(subject.AT.Asset.AssetCode4).To(BeNil())
-				Expect(subject.AT.Asset.AssetCode12).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
+				Expect(*subject.AT.Asset.AssetCode12).To(Equal([12]byte{'A', 'B', 'C', 'D', 'E', 'F', 0, 0, 0, 0, 0, 0}))
 			})
 		})
 	})
@@ -96,7 +95,6 @@ var _ = Describe("Payment Mutators", func() {
 			})
 
 			It("sets authorize flag properly", func() {
-				fmt.Println(subject.AT.Authorize)
 				Expect(subject.AT.Authorize).To(Equal(true))
 			})
 		})

--- a/build/create_account.go
+++ b/build/create_account.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"errors"
+	
 	"github.com/stellar/go-stellar-base/amount"
 	"github.com/stellar/go-stellar-base/xdr"
 )
@@ -35,6 +37,8 @@ func (b *CreateAccountBuilder) Mutate(muts ...interface{}) {
 			err = mut.MutateCreateAccount(&b.CA)
 		case OperationMutator:
 			err = mut.MutateOperation(&b.O)
+		default:
+			err = errors.New("Mutator type not allowed")
 		}
 
 		if err != nil {

--- a/build/main.go
+++ b/build/main.go
@@ -34,6 +34,17 @@ var (
 	DefaultNetwork = TestNetwork
 )
 
+// AllowTrustAsset is a mutator capable of setting the asset on
+// an operations that have one.
+type AllowTrustAsset struct {
+	Code string
+}
+
+// Authorize is a mutator capable of setting the `authorize` flag
+type Authorize struct {
+	Value bool
+}
+
 // Defaults is a mutator that sets defaults
 type Defaults struct{}
 
@@ -88,6 +99,12 @@ type Sign struct {
 // an xdr.Operation and an xdr.Transaction
 type SourceAccount struct {
 	AddressOrSeed string
+}
+
+// Trustor is a mutator capable of setting the trustor on
+// allow_trust operation.
+type Trustor struct {
+	Address string
 }
 
 // Network establishes the stellar network that a transaction should apply to.

--- a/build/payment.go
+++ b/build/payment.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"errors"
+	
 	"github.com/stellar/go-stellar-base/amount"
 	"github.com/stellar/go-stellar-base/xdr"
 )
@@ -34,6 +36,8 @@ func (b *PaymentBuilder) Mutate(muts ...interface{}) {
 			err = mut.MutatePayment(&b.P)
 		case OperationMutator:
 			err = mut.MutateOperation(&b.O)
+		default:
+			err = errors.New("Mutator type not allowed")
 		}
 
 		if err != nil {


### PR DESCRIPTION
This PR adds AllowTrust operation mutators and default arm to return an error if mutator is not of expected type.