### PR TITLE
Non-native payments mutators

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -45,6 +45,14 @@ type Authorize struct {
 	Value bool
 }
 
+// CreditAmount is a mutator that configures a payment to be using credit
+// asset and have the amount provided.
+type CreditAmount struct {
+	Code string
+	Issuer string
+	Amount string
+}
+
 // Defaults is a mutator that sets defaults
 type Defaults struct{}
 

--- a/build/payment.go
+++ b/build/payment.go
@@ -47,6 +47,41 @@ func (b *PaymentBuilder) Mutate(muts ...interface{}) {
 	}
 }
 
+// MutatePayment for Asset sets the PaymentOp's Asset field
+func (m CreditAmount) MutatePayment(o *xdr.PaymentOp) (err error) {
+	o.Amount, err = amount.Parse(m.Amount)
+	if err != nil {
+		return
+	}
+
+	length := len(m.Code)
+
+	var issuer xdr.AccountId
+	err = setAccountId(m.Issuer, &issuer)
+	if err != nil {
+		return
+	}
+
+	switch {
+	case length >= 1 && length <= 4:
+		var code [4]byte
+		byteArray := []byte(m.Code)
+		copy(code[:], byteArray[0:length])
+		asset := xdr.AssetAlphaNum4{code, issuer}
+		o.Asset, err = xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum4, asset)
+	case length >= 5 && length <= 12:
+		var code [12]byte
+		byteArray := []byte(m.Code)
+		copy(code[:], byteArray[0:length])
+		asset := xdr.AssetAlphaNum12{code, issuer}
+		o.Asset, err = xdr.NewAsset(xdr.AssetTypeAssetTypeCreditAlphanum12, asset)
+	default:
+		err = errors.New("Asset code length is invalid")
+	}
+
+	return
+}
+
 // MutatePayment for Destination sets the PaymentOp's Destination field
 func (m Destination) MutatePayment(o *xdr.PaymentOp) error {
 	return setAccountId(m.AddressOrSeed, &o.Destination)


### PR DESCRIPTION
Mutators to allow non-native payments in the builder. Usage:
```go
tx := b.Transaction(
	b.SourceAccount{source},
	b.Sequence{1},
	b.Payment(
		b.Destination{"GD42D7ENUOHDFOOFUUHQPHIIFCZZ2QCVRA4SDK3IY64JPWDFGTW3MJAB"},
		b.Amount{"50.0"},
		b.Asset{"USD", "GCTL3VQAWZ4HPC7VKRCKM3PVRGFHMEX5EIVZWW5OEFLTSJQ2GLD7B3I3"},
	),
)
```