### PR TITLE
Add AutoSequence build helper

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -90,6 +90,12 @@ type Authorize struct {
 	Value bool
 }
 
+// AutoSequence loads the sequence to use for the transaction from an external
+// provider.
+type AutoSequence struct {
+	SequenceProvider
+}
+
 // NativeAsset is a helper method to create native Asset object
 func NativeAsset() Asset {
 	return Asset{Native: true}
@@ -199,6 +205,12 @@ type Rate struct {
 // Sequence is a mutator that sets the sequence number on a transaction
 type Sequence struct {
 	Sequence uint64
+}
+
+// SequenceProvider is the interface that other packages may implement to be
+// used with the `AutoSequence` mutator.
+type SequenceProvider interface {
+	SequenceForAccount(aid string) (xdr.SequenceNumber, error)
 }
 
 // Sign is a mutator that contributes a signature of the provided envelope's

--- a/build/testing.go
+++ b/build/testing.go
@@ -1,0 +1,27 @@
+package build
+
+import (
+	"fmt"
+	"github.com/stellar/go-stellar-base/xdr"
+)
+
+// MockSequenceProvider is a mock sequence provider.
+type MockSequenceProvider struct {
+	Data map[string]xdr.SequenceNumber
+}
+
+var _ SequenceProvider = &MockSequenceProvider{}
+
+// SequenceForAccount implements `SequenceProvider`
+func (sp *MockSequenceProvider) SequenceForAccount(
+	accountID string,
+) (xdr.SequenceNumber, error) {
+
+	ret, ok := sp.Data[accountID]
+
+	if !ok {
+		return 0, fmt.Errorf("No sequence for %s in mock", accountID)
+	}
+
+	return ret, nil
+}

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -123,6 +123,18 @@ func (m AllowTrustBuilder) MutateTransaction(o *TransactionBuilder) error {
 	return m.Err
 }
 
+// MutateTransaction for AutoSequence loads the sequence and sets it on the tx.
+func (m AutoSequence) MutateTransaction(o *TransactionBuilder) error {
+	source := o.TX.SourceAccount
+	seq, err := m.SequenceForAccount(source.Address())
+	if err != nil {
+		return err
+	}
+
+	o.TX.SeqNum = seq
+	return nil
+}
+
 // MutateTransaction for ChangeTrustBuilder causes the underylying
 // CreateAccountOp to be added to the operation list for the provided
 // transaction

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -131,7 +131,7 @@ func (m AutoSequence) MutateTransaction(o *TransactionBuilder) error {
 		return err
 	}
 
-	o.TX.SeqNum = seq
+	o.TX.SeqNum = seq + 1
 	return nil
 }
 

--- a/build/transaction.go
+++ b/build/transaction.go
@@ -124,8 +124,15 @@ func (m AllowTrustBuilder) MutateTransaction(o *TransactionBuilder) error {
 }
 
 // MutateTransaction for AutoSequence loads the sequence and sets it on the tx.
+// NOTE:  this mutator assumes that the source account has already been set on
+// the transaction and will error if that has not occurred.
 func (m AutoSequence) MutateTransaction(o *TransactionBuilder) error {
 	source := o.TX.SourceAccount
+
+	if source == (xdr.AccountId{}) {
+		return errors.New("auto sequence used prior to setting source account")
+	}
+
 	seq, err := m.SequenceForAccount(source.Address())
 	if err != nil {
 		return err

--- a/build/transaction_test.go
+++ b/build/transaction_test.go
@@ -106,4 +106,30 @@ var _ = Describe("Transaction Mutators:", func() {
 		It("sets the sequence", func() { Expect(subject.TX.SeqNum).To(BeEquivalentTo(12345)) })
 	})
 
+	Describe("AutoSequence", func() {
+		BeforeEach(func() {
+			mock := &MockSequenceProvider{
+				Data: map[string]xdr.SequenceNumber{
+					"GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ": 2,
+				},
+			}
+
+			mut = AutoSequence{mock}
+		})
+
+		Context("with no source account set", func() {
+			It("fails", func() { Expect(subject.Err).To(HaveOccurred()) })
+		})
+
+		Context("with a source account set", func() {
+			BeforeEach(func() {
+				subject.Mutate(SourceAccount{
+					"GAXEMCEXBERNSRXOEKD4JAIKVECIXQCENHEBRVSPX2TTYZPMNEDSQCNQ",
+				})
+			})
+
+			It("succeeds", func() { Expect(subject.Err).NotTo(HaveOccurred()) })
+			It("sets the sequence", func() { Expect(subject.TX.SeqNum).To(BeEquivalentTo(3)) })
+		})
+	})
 })

--- a/horizon/main_test.go
+++ b/horizon/main_test.go
@@ -10,12 +10,15 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stellar/go-stellar-base/build"
 )
 
 func TestHorizon(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Package: github.com/stellar/go-stellar-base/horizon")
 }
+
+var _ build.SequenceProvider = TestHorizonClient
 
 var _ = Describe("Horizon", func() {
 	Describe("initHttpClient", func() {


### PR DESCRIPTION
It's not tested yet, but I wanted to get some feedback on this API:

```
	tx = build.Transaction(
		build.SourceAccount{seed},
		build.AutoSequence{horizon.DefaultTestNetClient},
		Payment(...)
	)
```

Thoughts?